### PR TITLE
Add xsl:choose block to account for different DISS_author types

### DIFF
--- a/MetadataCrosswalks/Proquest/Proquest_MODS.xsl
+++ b/MetadataCrosswalks/Proquest/Proquest_MODS.xsl
@@ -9,10 +9,20 @@
     <xsl:template match="/DISS_submission">
         <mods:mods xmlns:mods="http://www.loc.gov/mods/v3" xmlns:etdms="http://www.ndltd.org/standards/metadata/etdms/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" version="3.6" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd http://www.ndltd.org/standards/metadata/etdms/1-0/ http://www.ndltd.org/standards/metadata/etdms/1-0/etdms.xsd">
             <xsl:apply-templates select="DISS_description/DISS_title"/>
-            <xsl:apply-templates select="DISS_authorship/DISS_author[@type='additional']/DISS_name">
-                <xsl:with-param name="text">Author</xsl:with-param>
-                <xsl:with-param name="code">aut</xsl:with-param>                
-            </xsl:apply-templates>
+            <xsl:choose>
+                <xsl:when test="DISS_authorship/DISS_author[@type='primary']">
+                    <xsl:apply-templates select="DISS_authorship/DISS_author[@type='primary']/DISS_name">
+                        <xsl:with-param name="text">Author</xsl:with-param>
+                        <xsl:with-param name="code">aut</xsl:with-param>                
+                    </xsl:apply-templates>
+                </xsl:when>
+                <xsl:when test="DISS_authorship/DISS_author[@type='additional']">
+                    <xsl:apply-templates select="DISS_authorship/DISS_author[@type='additional']/DISS_name">
+                        <xsl:with-param name="text">Author</xsl:with-param>
+                        <xsl:with-param name="code">aut</xsl:with-param>                
+                    </xsl:apply-templates>
+                </xsl:when>
+            </xsl:choose>
             <xsl:apply-templates select="DISS_description/DISS_advisor/DISS_name">
                 <xsl:with-param name="text">Thesis advisor</xsl:with-param>
                 <xsl:with-param name="code">ths</xsl:with-param>   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Adds a conditional to the ProQuest XSLT to account for two different values of `DISS_author[@type]` for primary authors (`'additional'`, which is new, and `'primary'`). This follows up on PR #9 .

### Motivation and context
We thought that ProQuest had changed the schema such that all primary authors were identified as `@type='additional'`, but some ETDs still come in with `@type='primary'`, causing processProquest to fail.

### How has this been tested?
Tested successfully in dev, confirmed in prod environment.

### How can a reviewer see the effects of these changes?
Run Proquest_MODS.xslt on metadata for a ProQuest ETD.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have stakeholder approval to make this change.
